### PR TITLE
Refactor of part pack and res kits

### DIFF
--- a/1.4/Defs/ThingCategoryDefs/ThingCategories.xml
+++ b/1.4/Defs/ThingCategoryDefs/ThingCategories.xml
@@ -13,4 +13,10 @@
         <parent>Weapons</parent>
     </ThingCategoryDef>
 
+    <ThingCategoryDef>
+        <defName>ATR_FixPacks</defName>
+        <label>Repair kits</label>
+        <parent>Medicine</parent>
+    </ThingCategoryDef>
+
 </Defs>

--- a/1.4/Defs/ThingDefs_Items/Items_Resource_Manufactured.xml
+++ b/1.4/Defs/ThingDefs_Items/Items_Resource_Manufactured.xml
@@ -1,6 +1,8 @@
 ﻿<?xml version="1.0" encoding="utf-8" ?>
 <Defs>
 
+    <!-- All Parts Packs Base Def -->
+
     <ThingDef Name="ATR_PartPackBase" ParentName="ResourceBase" Abstract="True">
         <resourceReadoutPriority>Middle</resourceReadoutPriority>
         <useHitPoints>true</useHitPoints>
@@ -39,6 +41,7 @@
         </thingSetMakerTags>
     </ThingDef>
 
+    <!-- Mechanical Part Pack -->
     <ThingDef ParentName="ATR_PartPackBase">
         <defName>ATR_PartPack</defName>
         <label>Mechanical Part Pack</label>
@@ -65,7 +68,7 @@
         </recipeMaker>
     </ThingDef>
 
-    <!-- Resurrector Kits Base Def -->
+    <!-- Resurrector Kits Base Def (builds from Part Pack) -->
 
     <ThingDef Name="ATR_ApplicableKitBase" ParentName="ATR_PartPackBase" Abstract="True">
 	    <thingClass>ThingWithComps</thingClass>
@@ -328,73 +331,5 @@
             <li>FabricationBench</li>
         </recipeUsers>
     </RecipeDef>
-
-    <!-- Drone Resurrector Kit -->
-    <ThingDef ParentName="ATR_ApplicableKitBase">
-        <defName>ATR_DroneResurrectorKit</defName>
-        <label>Drone Resurrector Kit</label>
-        <description>A specialized suite of tools capable of bringing disabled simple mechanical drones back to life. The tools are sufficiently advanced to bring simple-minded mechanical units like animals back to life. Revived units must fully reboot in order to begin operating again.</description>
-        <graphicData>
-            <texPath>Things/Items/Manufactured/DroneResurrectionKit</texPath>
-            <graphicClass>Graphic_Single</graphicClass>
-        </graphicData>
-        <statBases>
-            <MarketValue>200</MarketValue>
-            <DeteriorationRate>2.0</DeteriorationRate>
-            <MaxHitPoints>80</MaxHitPoints>
-            <Mass>0.2</Mass>
-            <Flammability>0.2</Flammability>
-        </statBases>
-        <tradeability>Sellable</tradeability>
-        <thingSetMakerTags>
-            <li>RewardSpecial</li>
-        </thingSetMakerTags>
-    </ThingDef>
-
-    <RecipeDef>
-        <defName>ATR_DroneResurrectorKit</defName>
-        <label>Make a drone resurrector kit</label>
-        <description>Create a specialized suite of tools capable of bringing disabled simple mechanical drones back to life. The tools are sufficiently advanced to bring simple-minded mechanical units like animals back to life. Revived units must fully reboot in order to begin operating again.</description>
-        <jobString>Making drone resurrector kit</jobString>
-        <allowMixingIngredients>false</allowMixingIngredients>
-        <ingredients>
-            <li>
-                <filter>
-                    <thingDefs>
-                        <li>Steel</li>
-                    </thingDefs>
-                </filter>
-                <count>40</count>
-            </li>
-            <li>
-                <filter>
-                    <thingDefs>
-                        <li>Plasteel</li>
-                    </thingDefs>
-                </filter>
-                <count>20</count>
-            </li>
-            <li>
-                <filter>
-                    <thingDefs>
-                        <li>ComponentIndustrial</li>
-                    </thingDefs>
-                </filter>
-                <count>6</count>
-            </li>
-        </ingredients>
-        <products>
-            <ATR_DroneResurrectorKit>1</ATR_DroneResurrectorKit>
-        </products>
-        <workAmount>2450</workAmount>
-        <workSpeedStat>GeneralLaborSpeed</workSpeedStat>
-        <workSkill>Crafting</workSkill>
-        <effectWorking>Smelt</effectWorking>
-        <soundWorking>Recipe_Smelt</soundWorking>
-	    <recipeUsers>
-            <li>TableMachining</li>
-            <li>ATR_MechPartWorkbench</li>
-        </recipeUsers>
-	</RecipeDef>
 
 </Defs>

--- a/1.4/Defs/ThingDefs_Items/Items_Resource_Manufactured.xml
+++ b/1.4/Defs/ThingDefs_Items/Items_Resource_Manufactured.xml
@@ -1,135 +1,155 @@
 ﻿<?xml version="1.0" encoding="utf-8" ?>
 <Defs>
 
-    <ThingDef ParentName="ResourceBase">
-        <defName>ATR_PartPack</defName>
-        <label>Mechanical Part Pack</label>
-        <description>This pack of half-assembled parts is designed to replace standard components ranging from whole legs and arms to intricate batteries and adaptors. Programmed mechanites shape themselves to fit more complicated tasks.</description>
-        <graphicData>
-            <texPath>Things/Items/Manufactured/PartPack</texPath>
-            <graphicClass>Graphic_Single</graphicClass>
-        </graphicData>
+    <ThingDef Name="ATR_PartPackBase" ParentName="ResourceBase" Abstract="True">
+        <resourceReadoutPriority>Middle</resourceReadoutPriority>
+        <useHitPoints>true</useHitPoints>
+		<drawGUIOverlay>True</drawGUIOverlay>
+        <uiIconForStackCount>1</uiIconForStackCount>
         <soundInteract>Standard_Drop</soundInteract>
         <soundDrop>Standard_Drop</soundDrop>
-		<stackLimit>25</stackLimit>
         <statBases>
             <MaxHitPoints>60</MaxHitPoints>
             <MarketValue>30</MarketValue>
             <Mass>0.45</Mass>
             <Flammability>0</Flammability>
         </statBases>
+        <intricate>true</intricate>
         <thingCategories>
-            <li>Manufactured</li>
+            <li>ATR_FixPacks</li>
         </thingCategories>
-        <tradeability>All</tradeability>
         <techLevel>Industrial</techLevel>
         <tradeTags>
             <li>ExoticMisc</li>
         </tradeTags>
+        <recipeMaker>
+            <workSpeedStat>GeneralLaborSpeed</workSpeedStat>
+            <workSkill>Crafting</workSkill>
+            <effectWorking>Smelt</effectWorking>
+            <soundWorking>Recipe_Smelt</soundWorking>
+            <recipeUsers>
+                <li>TableMachining</li>
+                <li>ATR_MechPartWorkbench</li>
+            </recipeUsers>
+            <unfinishedThingDef>UnfinishedComponent</unfinishedThingDef>
+        </recipeMaker>
         <thingSetMakerTags>
+            <li>Manufactured</li>
             <li>RewardSpecial</li>
         </thingSetMakerTags>
     </ThingDef>
 
-    <RecipeDef>
+    <ThingDef ParentName="ATR_PartPackBase">
         <defName>ATR_PartPack</defName>
-        <label>Make a mechanical part pack</label>
-        <description>Create a pack of half-assembled parts designed to replace standard components ranging from whole legs and arms to intricate batteries and adaptors. Programmed mechanites shape themselves to fit more complicated tasks.</description>
-        <jobString>Making part pack</jobString>
-        <allowMixingIngredients>false</allowMixingIngredients>
-        <ingredients>
-            <li>
-                <filter>
-                    <thingDefs>
-                        <li>Steel</li>
-                    </thingDefs>
-                </filter>
-                <count>40</count>
-            </li>
-            <li>
-                <filter>
-                    <thingDefs>
-                        <li>Plasteel</li>
-                    </thingDefs>
-                </filter>
-                <count>20</count>
-            </li>
-            <li>
-                <filter>
-                    <thingDefs>
-                        <li>ComponentIndustrial</li>
-                    </thingDefs>
-                </filter>
-                <count>6</count>
-            </li>
-        </ingredients>
-        <products>
-            <ATR_PartPack>4</ATR_PartPack>
-        </products>
-        <workAmount>2150</workAmount>
-        <workSpeedStat>GeneralLaborSpeed</workSpeedStat>
-        <workSkill>Crafting</workSkill>
-        <effectWorking>Smelt</effectWorking>
-        <soundWorking>Recipe_Smelt</soundWorking>
-        <recipeUsers>
-            <li>TableMachining</li>
-            <li>ATR_MechPartWorkbench</li>
-        </recipeUsers>
-        </RecipeDef>
+        <label>Mechanical Part Pack</label>
+        <description>This pack of half-assembled parts is designed to replace standard components ranging from whole legs and arms to intricate batteries and adaptors. Basic pre-programmed mechanites shape themselves to fit more complicated tasks.</description>
+        <graphicData>
+            <texPath>Things/Items/Manufactured/PartPack</texPath>
+            <graphicClass>Graphic_Single</graphicClass>
+        </graphicData>
+        <stackLimit>25</stackLimit>
+        <statBases>
+            <WorkToMake>2150</WorkToMake>
+        </statBases>
+        <costList>
+            <Steel>40</Steel>
+            <Plasteel>20</Plasteel>
+            <ComponentIndustrial>6</ComponentIndustrial>
+        </costList>
+        <tradeability>All</tradeability>
+        <recipeMaker>
+            <bulkRecipeCount>4</bulkRecipeCount>
+            <skillRequirements>
+                <Crafting>6</Crafting>
+            </skillRequirements>
+        </recipeMaker>
+    </ThingDef>
 
-    <RecipeDef>
-        <defName>ATR_MakeAIPersonaCore</defName>
-        <label>Make an AI persona core</label>
-        <description>Create a complexe AI core capable of sentience.</description>
-        <jobString>Making AI Core</jobString>
-        <allowMixingIngredients>false</allowMixingIngredients>
-        <ingredients>
-            <li>
-                <filter>
-                    <thingDefs>
-                        <li>Plasteel</li>
-                    </thingDefs>
-                </filter>
-                <count>120</count>
+    <!-- Resurrector Kits Base Def -->
+
+    <ThingDef Name="ATR_ApplicableKitBase" ParentName="ATR_PartPackBase" Abstract="True">
+	    <thingClass>ThingWithComps</thingClass>
+        <stackLimit>10</stackLimit>
+        <tradeNeverStack>true</tradeNeverStack>
+        <comps>
+            <li Class="CompProperties_Usable">
+                <useJob>UseItem</useJob>
+                <useLabel>Use resurrector kit</useLabel>
+                <useDuration>0</useDuration>
+                <warmupMote>Mote_ResurrectAbility</warmupMote>
+            </li>
+            <li Class="CompProperties_Targetable">
+                <compClass>CompTargetable_SingleCorpse</compClass>
+                <nonDessicatedCorpsesOnly>true</nonDessicatedCorpsesOnly>
             </li>
             <li>
-                <filter>
-                    <thingDefs>
-                        <li>Uranium</li>
-                    </thingDefs>
-                </filter>
-                <count>30</count>
+                <compClass>ATReforged.CompTargetEffect_ResurrectMechanical</compClass>
             </li>
-            <li>
-                <filter>
-                    <thingDefs>
-                        <li>Gold</li>
-                    </thingDefs>
-                </filter>
-                <count>10</count>
-            </li>
-            <li>
-                <filter>
-                    <thingDefs>
-                        <li>ComponentSpacer</li>
-                    </thingDefs>
-                </filter>
-                <count>10</count>
-            </li>
-        </ingredients>
-        <products>
-            <AIPersonaCore>1</AIPersonaCore>
-        </products>
-        <workAmount>8650</workAmount>
-        <researchPrerequisite>ATR_ArchotechInsight</researchPrerequisite>
-        <workSpeedStat>GeneralLaborSpeed</workSpeedStat>
-        <workSkill>Crafting</workSkill>
-        <effectWorking>Smelt</effectWorking>
-        <soundWorking>Recipe_Smelt</soundWorking>
-        <recipeUsers>
-            <li>FabricationBench</li>
-        </recipeUsers>
-    </RecipeDef>
+        </comps>
+        <tradeability>Sellable</tradeability>
+    </ThingDef>
+
+    <!-- Drone Resurrector Kit -->
+    <ThingDef ParentName="ATR_ApplicableKitBase">
+        <defName>ATR_DroneResurrectorKit</defName>
+        <label>Drone Resurrector Kit</label>
+        <description>A specialized suite of tools capable of bringing disabled simple mechanical drones back to life. The tools are sufficiently advanced to bring simple-minded mechanical units like animals back to life. Revived units must fully reboot in order to begin operating again.</description>
+        <graphicData>
+            <texPath>Things/Items/Manufactured/DroneResurrectionKit</texPath>
+            <graphicClass>Graphic_Single</graphicClass>
+        </graphicData>
+        <statBases>
+            <MarketValue>200</MarketValue>
+            <DeteriorationRate>2.0</DeteriorationRate>
+            <MaxHitPoints>80</MaxHitPoints>
+            <Mass>0.2</Mass>
+            <Flammability>0.2</Flammability>
+            <WorkToMake>2450</WorkToMake>
+        </statBases>
+        <costList>
+            <Steel>40</Steel>
+            <Plasteel>20</Plasteel>
+            <ComponentIndustrial>6</ComponentIndustrial>
+        </costList>
+        <recipeMaker>
+            <skillRequirements>
+                <Crafting>8</Crafting>
+            </skillRequirements>
+            <researchPrerequisite>ATR_MechanicalInsight</researchPrerequisite>
+        </recipeMaker>
+    </ThingDef>
+
+    <!-- Android Resurrection Kit -->
+    <ThingDef ParentName="ATR_ApplicableKitBase">
+        <defName>ATR_AndroidResurrectorKit</defName>
+        <label>Android Resurrector Kit</label>
+        <description>A specialized suite of tools capable of bringing disabled mechanical units back to life. The tools are sufficiently advanced to bring any such unit back to nominal functionality. Revived units must fully reboot in order to begin operating again.</description>
+        <graphicData>
+            <texPath>Things/Items/Manufactured/AndroidResurrectionKit</texPath>
+            <graphicClass>Graphic_Single</graphicClass>
+        </graphicData>
+        <statBases>
+            <MarketValue>300</MarketValue>
+            <DeteriorationRate>2.0</DeteriorationRate>
+            <MaxHitPoints>80</MaxHitPoints>
+            <Mass>0.2</Mass>
+            <Flammability>0.2</Flammability>
+            <WorkToMake>4550</WorkToMake>
+        </statBases>
+        <costList>
+            <Steel>80</Steel>
+            <Plasteel>40</Plasteel>
+            <Gold>2</Gold>
+            <ComponentIndustrial>10</ComponentIndustrial>
+            <ComponentSpacer>2</ComponentSpacer>
+        </costList>
+        <recipeMaker>
+            <skillRequirements>
+                <Crafting>10</Crafting>
+            </skillRequirements>
+            <researchPrerequisite>ATR_MechaniteAssistedRecovery</researchPrerequisite>
+        </recipeMaker>
+    </ThingDef>
 
     <!-- Repair Stim Base -->
 
@@ -253,103 +273,35 @@
         </recipeMaker>
     </ThingDef>
 
-    <!-- Resurrector Kits -->
-
-    <ThingDef Name="ATR_ApplicableKitBase" ParentName="ResourceBase" Abstract="True">
-	    <thingClass>ThingWithComps</thingClass>
-        <resourceReadoutPriority>Middle</resourceReadoutPriority>
-        <useHitPoints>true</useHitPoints>
-        <stackLimit>10</stackLimit>
-        <intricate>true</intricate>
-        <tradeNeverStack>true</tradeNeverStack>
-	    <thingCategories>
-            <li>Items</li>
-        </thingCategories>
-        <drawGUIOverlay>true</drawGUIOverlay>
-        <soundInteract>Metal_Drop</soundInteract>
-        <soundDrop>Standard_Drop</soundDrop>
-        <comps>
-            <li Class="CompProperties_Usable">
-                <useJob>UseItem</useJob>
-                <useLabel>Use resurrector kit</useLabel>
-                <useDuration>0</useDuration>
-                <warmupMote>Mote_ResurrectAbility</warmupMote>
-            </li>
-            <li Class="CompProperties_Targetable">
-                <compClass>CompTargetable_SingleCorpse</compClass>
-                <nonDessicatedCorpsesOnly>true</nonDessicatedCorpsesOnly>
-            </li>
-            <li>
-                <compClass>ATReforged.CompTargetEffect_ResurrectMechanical</compClass>
-            </li>
-        </comps>
-        <tradeability>Sellable</tradeability>
-        <thingSetMakerTags>
-            <li>Manufactured</li>
-        </thingSetMakerTags>
-	    <techLevel>Industrial</techLevel>
-        <tradeTags>
-            <li>ExoticMisc</li>
-        </tradeTags>
-    </ThingDef>
-
-    <!-- Android Resurrection Kit -->
-    <ThingDef ParentName="ATR_ApplicableKitBase">
-        <defName>ATR_AndroidResurrectorKit</defName>
-        <label>Android Resurrector Kit</label>
-        <description>A specialized suite of tools capable of bringing disabled mechanical units back to life. The tools are sufficiently advanced to bring any such unit back to nominal functionality. Revived units must fully reboot in order to begin operating again.</description>
-        <graphicData>
-            <texPath>Things/Items/Manufactured/AndroidResurrectionKit</texPath>
-            <graphicClass>Graphic_Single</graphicClass>
-        </graphicData>
-        <statBases>
-            <MarketValue>300</MarketValue>
-            <DeteriorationRate>2.0</DeteriorationRate>
-            <MaxHitPoints>80</MaxHitPoints>
-            <Mass>0.2</Mass>
-            <Flammability>0.2</Flammability>
-        </statBases>
-        <tradeability>Sellable</tradeability>
-        <thingSetMakerTags>
-            <li>RewardSpecial</li>
-        </thingSetMakerTags>
-    </ThingDef>
+    <!-- AI Persona Core Recipe -->
 
     <RecipeDef>
-        <defName>ATR_AndroidResurrectorKit</defName>
-        <label>Make an android resurrector kit</label>
-        <description>Create a specialized kit of tools capable of reviving offline mechanical units to full functionality. The process of reactivating a deceased unit can be exceedingly expensive due to the inherent difficulties of restoring a deceased intelligence.</description>
-        <jobString>Making android resurrector kit</jobString>
+        <defName>ATR_MakeAIPersonaCore</defName>
+        <label>Make an AI persona core</label>
+        <description>Create a complexe AI core capable of sentience.</description>
+        <jobString>Making AI Core</jobString>
         <allowMixingIngredients>false</allowMixingIngredients>
         <ingredients>
-            <li>
-                <filter>
-                    <thingDefs>
-                        <li>Steel</li>
-                    </thingDefs>
-                </filter>
-                <count>80</count>
-            </li>
             <li>
                 <filter>
                     <thingDefs>
                         <li>Plasteel</li>
                     </thingDefs>
                 </filter>
-                <count>40</count>
+                <count>120</count>
+            </li>
+            <li>
+                <filter>
+                    <thingDefs>
+                        <li>Uranium</li>
+                    </thingDefs>
+                </filter>
+                <count>30</count>
             </li>
             <li>
                 <filter>
                     <thingDefs>
                         <li>Gold</li>
-                    </thingDefs>
-                </filter>
-                <count>2</count>
-            </li>
-            <li>
-                <filter>
-                    <thingDefs>
-                        <li>ComponentIndustrial</li>
                     </thingDefs>
                 </filter>
                 <count>10</count>
@@ -360,22 +312,22 @@
                         <li>ComponentSpacer</li>
                     </thingDefs>
                 </filter>
-                <count>2</count>
+                <count>10</count>
             </li>
         </ingredients>
         <products>
-            <ATR_AndroidResurrectorKit>1</ATR_AndroidResurrectorKit>
+            <AIPersonaCore>1</AIPersonaCore>
         </products>
-        <workAmount>4550</workAmount>
+        <workAmount>8650</workAmount>
+        <researchPrerequisite>ATR_ArchotechInsight</researchPrerequisite>
         <workSpeedStat>GeneralLaborSpeed</workSpeedStat>
         <workSkill>Crafting</workSkill>
         <effectWorking>Smelt</effectWorking>
         <soundWorking>Recipe_Smelt</soundWorking>
-	    <recipeUsers>
-            <li>TableMachining</li>
-            <li>ATR_MechPartWorkbench</li>
+        <recipeUsers>
+            <li>FabricationBench</li>
         </recipeUsers>
-	</RecipeDef>
+    </RecipeDef>
 
     <!-- Drone Resurrector Kit -->
     <ThingDef ParentName="ATR_ApplicableKitBase">

--- a/1.4/Defs/ThingDefs_Items/Items_Resource_Manufactured.xml
+++ b/1.4/Defs/ThingDefs_Items/Items_Resource_Manufactured.xml
@@ -118,7 +118,6 @@
             <skillRequirements>
                 <Crafting>8</Crafting>
             </skillRequirements>
-            <researchPrerequisite>ATR_MechanicalInsight</researchPrerequisite>
         </recipeMaker>
     </ThingDef>
 
@@ -150,7 +149,6 @@
             <skillRequirements>
                 <Crafting>10</Crafting>
             </skillRequirements>
-            <researchPrerequisite>ATR_MechaniteAssistedRecovery</researchPrerequisite>
         </recipeMaker>
     </ThingDef>
 
@@ -281,7 +279,7 @@
     <RecipeDef>
         <defName>ATR_MakeAIPersonaCore</defName>
         <label>Make an AI persona core</label>
-        <description>Create a complexe AI core capable of sentience.</description>
+        <description>Create a complex AI core capable of sentience.</description>
         <jobString>Making AI Core</jobString>
         <allowMixingIngredients>false</allowMixingIngredients>
         <ingredients>


### PR DESCRIPTION
This refactors the xml defs for the part packs and resurrector kits to use all ThingDefs instead of RecipeDefs that are properly built up with abstract base ThingDefs.
Also groups them together instead of having all the repair stims in between the part pack and ressurector kits.

~~Includes tech prerequisites based on #18 and will probably need some conflicts to be resolved once that is merged.
(I have another branch that's strictly derivative from that, so this one is up for inspection, and if the diff gets funky later I can use the derivative branch to overcome funkiness.)~~

Also adds all these packs into their own category under Medicine for ease of sorting and finding.

